### PR TITLE
Updated callOMDB() - clear metadata stack

### DIFF
--- a/assets/js/getMovieInfo.js
+++ b/assets/js/getMovieInfo.js
@@ -101,6 +101,10 @@ function callOMDB() {
 
 		.then(function (data1) {
 			// console.log(data1);
+
+			// clear metadata stack
+			clearMovieInfo();
+			
 			// for each movie search result
 			for (i = 0; i < data1.Search.length; i++) {
 				// push the general metadata
@@ -160,9 +164,14 @@ function renderFunction() {
 	}
 }
 
-//Renders movie results//
+// Clear metadata stack
 function clearMovieInfo() {
-	while (posters.length > 0) {
-		posters.pop();
-	}
+	while (posters.pop())
+	while (titles.pop());
+	while (years.pop());
+	while (ratings.pop());
+	while (esrbs.pop());
+	while (genres.pop());
+	while (actors.pop());
+	while (plots.pop());
 }


### PR DESCRIPTION
I modified callOMDB() to include a new function clearMovieInfo() which will clear the metadata stack before pushing, so now the movie results will replace the old search rather than appending to the old search