### PR TITLE
Updated showTrailer.js: added clearTrailer()

### DIFF
--- a/assets/js/modalPop.js
+++ b/assets/js/modalPop.js
@@ -13,6 +13,7 @@ $(document).ready(function () {
 		opacity: 0.9,
 		inDuration: 500,
 		outDuration: 500,
+		onCloseEnd: clearTrailer,
 	});
 
 	M.Dropdown.init(savedSearches, {
@@ -21,6 +22,13 @@ $(document).ready(function () {
 	});
 });
 
+function clearTrailer() {
+	// clear trailer from metadata
+	while (trailerURL.pop());
+	// clear trailer from iframe
+	var movieEl = document.querySelector('.modal-content');
+	movieEl.innerHTML = '';
+}
 // function modalToggler() {
 // 	var elem = $("#modal1");
 // 	instance = M.Modal.getInstance(elem);


### PR DESCRIPTION
I modified modalPop.js by adding a new function clearTrailer() which clears the trailer from the iframe when the Close Modal button is pressed. Now trailer buttons can be pressed an indefinite number of times and a new trailer will replace the old trailer